### PR TITLE
Update composer.json for PHP 8.0.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^5.5.9 || ^7.0 || 8.0",
+        "php": "^5.5.9 || ^7.0 || ^8.0",
         "illuminate/support": "5.* || ^6 || ^7 || ^8",
         "guzzlehttp/guzzle": "^6 || ^7",
         "monolog/monolog": "^1.12|^2.0"


### PR DESCRIPTION
Previously I got error when tried to update dependencies on PHP 8 build

`code-lts/laravel-fcm dev-main requires php ^5.5.9 || ^7.0 || 8.0 -> your php version (8.0.2) does not satisfy that requirement.`

After fixing to ^8.0 update was successful (tried to do that on fork).
Tested on method FCM::sendTo() - works correctly.