### PR TITLE
Multiple FCM Account Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ $notification = $notificationBuilder->build();
 $topic = new Topics();
 $topic->topic('news');
 
-$topicResponse = FCM::sendToTopic($topic, null, $notification, null);
+$topicResponse = FCM::sendToTopic($topic, null, $notification, null, $senderId, $serverKey);
 
 $topicResponse->isSuccess();
 $topicResponse->shouldRetry();

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Laravel-FCM (maintained version of the abandonned "official" repository)
+# Laravel-FCM (added support for multiple FCM account on code-lts/Laravel-FCM repository)
 
 ![Run tests](https://github.com/code-lts/Laravel-FCM/workflows/Run%20tests/badge.svg?branch=main)
 [![Coverage Status](https://codecov.io/gh/code-lts/laravel-fcm/branch/main/graph/badge.svg)](https://codecov.io/gh/code-lts/laravel-fcm)
@@ -157,7 +157,7 @@ $data = $dataBuilder->build();
 
 $token = "a_registration_from_your_database";
 
-$downstreamResponse = FCM::sendTo($token, $option, $notification, $data);
+$downstreamResponse = FCM::sendTo($token, $option, $notification, $data, $senderId, $serverKey);
 
 $downstreamResponse->numberSuccess();
 $downstreamResponse->numberFailure();
@@ -196,7 +196,7 @@ $data = $dataBuilder->build();
 // You must change it to get your tokens
 $tokens = MYDATABASE::pluck('fcm_token')->toArray();
 
-$downstreamResponse = FCM::sendTo($tokens, $option, $notification, $data);
+$downstreamResponse = FCM::sendTo($tokens, $option, $notification, $data, $senderId, $serverKey);
 
 $downstreamResponse->numberSuccess();
 $downstreamResponse->numberFailure();
@@ -271,7 +271,7 @@ $topic->topic('news')->andTopic(function($condition) {
 
 });
 
-$topicResponse = FCM::sendToTopic($topic, null, $notification, null);
+$topicResponse = FCM::sendToTopic($topic, null, $notification, null, $senderId, $serverKey);
 
 $topicResponse->isSuccess();
 $topicResponse->shouldRetry();
@@ -320,7 +320,7 @@ $notification = $notificationBuilder->build();
 
 $notificationKey = ['a_notification_key'];
 
-$groupResponse = FCM::sendToGroup($notificationKey, null, $notification, null);
+$groupResponse = FCM::sendToGroup($notificationKey, null, $notification, null, $senderId, $serverKey);
 
 $groupResponse->numberSuccess();
 $groupResponse->numberFailure();

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -52,8 +52,10 @@ class Request extends BaseRequest
      * @param PayloadNotification $notification
      * @param PayloadData         $data
      * @param Topics|null         $topic
+     * @param string              $senderId
+     * @param string              $serverKey
      */
-    public function __construct($to, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null, Topics $topic = null)
+    public function __construct($to, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null, Topics $topic = null, $senderId = null, $serverKey = null)
     {
         parent::__construct();
 
@@ -62,6 +64,14 @@ class Request extends BaseRequest
         $this->notification = $notification;
         $this->data = $data;
         $this->topic = $topic;
+
+        if ($senderId !== null) {
+            $this->config['sender_id'] = $senderId;
+        }
+
+        if ($serverKey !== null) {
+            $this->config['server_key'] = $serverKey;
+        }
     }
 
     /**

--- a/src/Sender/FCMSender.php
+++ b/src/Sender/FCMSender.php
@@ -23,10 +23,12 @@ class FCMSender extends HTTPSender
      * @param Options|null             $options
      * @param PayloadNotification|null $notification
      * @param PayloadData|null         $data
+     * @param string                   $senderId
+     * @param string                   $serverKey
      *
      * @return DownstreamResponse|null
      */
-    public function sendTo($to, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null)
+    public function sendTo($to, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null, $senderId = null, $serverKey = null)
     {
         $response = null;
 
@@ -45,7 +47,7 @@ class FCMSender extends HTTPSender
                 }
             }
         } else {
-            $request = new Request($to, $options, $notification, $data);
+            $request = new Request($to, $options, $notification, $data, null, $senderId, $serverKey);
             $responseGuzzle = $this->post($request);
 
             $response = new DownstreamResponse($responseGuzzle, $to, $this->logger);
@@ -61,12 +63,14 @@ class FCMSender extends HTTPSender
      * @param Options|null             $options
      * @param PayloadNotification|null $notification
      * @param PayloadData|null         $data
+     * @param string                   $senderId
+     * @param string                   $serverKey
      *
      * @return GroupResponse
      */
-    public function sendToGroup($notificationKey, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null)
+    public function sendToGroup($notificationKey, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null, $senderId = null, $serverKey = null)
     {
-        $request = new Request($notificationKey, $options, $notification, $data);
+        $request = new Request($notificationKey, $options, $notification, $data, null, $senderId, $serverKey);
 
         $responseGuzzle = $this->post($request);
 
@@ -80,12 +84,14 @@ class FCMSender extends HTTPSender
      * @param Options|null             $options
      * @param PayloadNotification|null $notification
      * @param PayloadData|null         $data
+     * @param string                   $senderId
+     * @param string                   $serverKey
      *
      * @return TopicResponse
      */
-    public function sendToTopic(Topics $topics, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null)
+    public function sendToTopic(Topics $topics, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null, $senderId = null, $serverKey = null)
     {
-        $request = new Request(null, $options, $notification, $data, $topics);
+        $request = new Request(null, $options, $notification, $data, $topics, $senderId, $serverKey);
 
         $responseGuzzle = $this->post($request);
 


### PR DESCRIPTION
Hello,

I have modified the below files for supporting multiple FCM account i.e. combinations of Sender ID and Sever Key. This is to handle a scenario where this library needs to be part of say a Microservices handling FCM request from multiple applications.

Laravel-FCM/src/Request/Request.php
Laravel-FCM/src/Sender/FCMSender.php
Thank you

Anuj Gandhi